### PR TITLE
Add CODEOWNERS and document maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners for AgentBreak.
+# These users are automatically requested for review on pull requests.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owners for everything in the repo
+*       @mnvsk97 @bennjph
+
+# Fault catalog
+/agentbreak/faults/    @mnvsk97 @bennjph
+
+# Tests
+/tests/                @mnvsk97 @bennjph

--- a/README.md
+++ b/README.md
@@ -214,3 +214,12 @@ agentbreak history compare 1 2          # compare two saved runs
 - **Skill-based attacks** — target agent skills/capabilities with adversarial tool sequences
 - **Deprecated library injection** — return responses referencing deprecated or vulnerable libraries
 - **Model deprecation simulation** — simulate model sunset responses and version migration failures
+
+## Maintainers
+
+AgentBreak is maintained by:
+
+- [@mnvsk97](https://github.com/mnvsk97) — creator
+- [@bennjph](https://github.com/bennjph) — maintainer
+
+Reviews on pull requests are routed via [`.github/CODEOWNERS`](.github/CODEOWNERS). See [CONTRIBUTING.md](CONTRIBUTING.md) to get started.


### PR DESCRIPTION
## What

- Adds `.github/CODEOWNERS` so PRs automatically request review from the maintainers.
- Adds a **Maintainers** section to the README naming who's responsible for the project.

## Why

The repo has active maintainers but no machine-readable or documented record of who they are. CODEOWNERS:

- Auto-requests maintainer review on every PR (so nothing slips through unreviewed)
- Makes the maintainer roster explicit and public

> **Note for @mnvsk97:** this lists `@bennjph` as a maintainer alongside you. For CODEOWNERS routing to actually request my review, I'll need write/maintain access on the repo — happy to adjust the names/paths if you'd rather scope it differently.

No code changes; docs + config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)